### PR TITLE
feat: adds default status parameter for representative

### DIFF
--- a/src/components/NegotiationList.vue
+++ b/src/components/NegotiationList.vue
@@ -374,6 +374,7 @@
         </li>
         <li
           v-for="page in pagination.totalPages"
+          :key="page"
           class="page-item"
         >
           <a
@@ -550,7 +551,7 @@ export default {
       return this.negotiations === undefined
     },
     dateFilterLength () {
-      if (this.filters.dateStart !== "" && this.filters.dateEnd != "") {
+      if (this.filters.dateStart !== "" && this.filters.dateEnd !== "") {
         return 2
       }
       return 1

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -105,8 +105,16 @@ export default {
         return []
       })
   },
-  retrieveNegotiationsByRole ({ state, commit }, { role, userId, statusFilter, pageNumber }) {
-    return axios.get(`${BASE_API_PATH}/users/${userId}/negotiations`, { headers: getBearerHeaders(state.oidc.access_token), params: { role, status: statusFilter, page: pageNumber } })
+  retrieveNegotiationsByRoleAndStatus ({ state, commit }, { role, status, userId, pageNumber }) {
+    if (status instanceof Array) {
+      status = status.join(",")
+    }
+    const parameters = {
+      headers: getBearerHeaders(state.oidc.access_token),
+      params: { role, status, page: pageNumber }
+    }
+
+    return axios.get(`${BASE_API_PATH}/users/${userId}/negotiations`, parameters)
       .then((response) => {
         return response.data
       })

--- a/src/views/UserPage.vue
+++ b/src/views/UserPage.vue
@@ -3,8 +3,8 @@
     :negotiations="negotiations"
     :pagination="pagination"
     :user-role="userRole"
-    @currentPageNumber="retrieveNegotiationsByPage"
-    @filterStatus="retrieveNegotiationsByFilterStatus"
+    @current-page-number="retrieveNegotiationsByPage"
+    @filter-status="retrieveNegotiationsByFilterStatus"
   />
 </template>
 <script>
@@ -37,14 +37,20 @@ export default {
     }
   },
   async mounted () {
-    this.user = await await this.retrieveUser()
+    this.user = await this.retrieveUser()
     this.userId = this.user.users[0].id
 
-    if (this.userRole === "ROLE_ADMIN") { this.negotiations = await this.retrieveNegotiations({ statusFilter: "SUBMITTED", pageNumber: 0 }) }
+    if (this.userRole === "ROLE_ADMIN") {
+      this.negotiations = await this.retrieveNegotiations({ statusFilter: "SUBMITTED", pageNumber: 0 })
+    }
 
-    if (this.userRole === "ROLE_RESEARCHER") { this.negotiations = await this.retrieveNegotiationsByRole({ role: "author", userId: this.userId, pageNumber: 0 }) }
+    if (this.userRole === "ROLE_RESEARCHER") {
+      this.negotiations = await this.retrieveNegotiationsByRoleAndStatus({ role: "author", userId: this.userId, pageNumber: 0 })
+    }
 
-    if (this.userRole === "ROLE_REPRESENTATIVE") { this.negotiations = await this.retrieveNegotiationsByRole({ role: "representative", userId: this.userId, pageNumber: 0 }) }
+    if (this.userRole === "ROLE_REPRESENTATIVE") {
+      this.negotiations = await this.retrieveNegotiationsByRoleAndStatus({ role: "representative", status: ["IN_PROGRESS", "ABANDONED"], userId: this.userId, pageNumber: 0 })
+    }
 
     this.pagination = this.negotiations.page
     if (this.negotiations.page.totalElements === 0) {
@@ -54,19 +60,27 @@ export default {
     }
   },
   methods: {
-    ...mapActions(["retrieveNegotiationsByRole", "retrieveNegotiations", "retrieveUser", "retrieveUserRoles"]),
+    ...mapActions(["retrieveNegotiationsByRoleAndStatus", "retrieveNegotiations", "retrieveUser", "retrieveUserRoles"]),
     async retrieveNegotiationsByPage (currentPageNumber) {
-      if (this.userRole === "ROLE_ADMIN") { this.negotiations = await this.retrieveNegotiations({ statusFilter: "SUBMITTED", pageNumber: currentPageNumber - 1 }) }
+      if (this.userRole === "ROLE_ADMIN") {
+        this.negotiations = await this.retrieveNegotiations({ status: "SUBMITTED", pageNumber: currentPageNumber - 1 })
+      }
 
-      if (this.userRole === "ROLE_RESEARCHER") { this.negotiations = await this.retrieveNegotiationsByRole({ role: "author", userId: this.userId, pageNumber: currentPageNumber - 1 }) }
+      if (this.userRole === "ROLE_RESEARCHER") {
+        this.negotiations = await this.retrieveNegotiationsByRoleAndStatus({ role: "author", userId: this.userId, pageNumber: currentPageNumber - 1 })
+      }
 
-      if (this.userRole === "ROLE_REPRESENTATIVE") { this.negotiations = await this.retrieveNegotiationsByRole({ role: "representative", userId: this.userId, pageNumber: currentPageNumber - 1 }) }
+      if (this.userRole === "ROLE_REPRESENTATIVE") {
+        this.negotiations = await this.retrieveNegotiationsByRoleAndStatus({ role: "representative", status: ["IN_PROGRESS", "ABANDONED"], userId: this.userId, pageNumber: currentPageNumber - 1 })
+      }
 
       // this.negotiations = await this.retrieveNegotiationsByRole({ userId: this.userId, pageNumber: currentPageNumber })
-      if (this.negotiations._embedded) { this.negotiations = this.negotiations._embedded.negotiations }
+      if (this.negotiations._embedded) {
+        this.negotiations = this.negotiations._embedded.negotiations
+      }
     },
     async retrieveNegotiationsByFilterStatus (filterStatus) {
-      this.negotiations = await this.retrieveNegotiationsByRole({ userId: this.userId, pageNumber: 0, statusFilter: filterStatus })
+      this.negotiations = await this.retrieveNegotiationsByRoleAndStatus({ userId: this.userId, pageNumber: 0, status: filterStatus })
       if (this.negotiations._embedded) { this.negotiations = this.negotiations._embedded.negotiations }
     }
   }


### PR DESCRIPTION
After [PR 208](https://github.com/BBMRI-ERIC/negotiator/pull/208), the backend leaves the client the responsibility of filters. This means that, by default, the representative gets all the negotiations, no matter the status.
This PR adds the status filter to the action that gets the negotiations, and, in the case of the representative user, it applies IN_PROGRESS and ABANDONED filter, by default