### PR TITLE
feat: add feature to set featureflags from URL  params

### DIFF
--- a/src/config/featureFlags.js
+++ b/src/config/featureFlags.js
@@ -12,6 +12,37 @@ const prodSettings = {
 
 let allFeatureFlags
 
+function getSearchParameters () {
+  const prmstr = window.location.search.substr(1)
+  return prmstr != null && prmstr != "" ? transformToAssocArray(prmstr) : {}
+}
+
+function transformToAssocArray (prmstr) {
+  const params = {}
+  const prmarr = prmstr.split("&")
+  for (let i = 0; i < prmarr.length; i++) {
+    const tmparr = prmarr[i].split("=")
+    params[tmparr[0]] = tmparr[1]
+  }
+  return params
+}
+
+const params = getSearchParameters()
+
+function setFeatureFlagsFromParams () {
+  for (const key in params) {
+    if (devSettings[key] || prodSettings[key]) {
+      if (import.meta.env.DEV) {
+        devSettings[key] = params[key]
+      } else {
+        prodSettings[key] = params[key]
+      }
+    }
+  }
+}
+
+setFeatureFlagsFromParams()
+
 if (import.meta.env.DEV) {
   allFeatureFlags = devSettings
 } else {


### PR DESCRIPTION
add functionality to set featureFlags from URL params

example:
`http://localhost:8080/researcher?faqPage=true&vueTour=false`